### PR TITLE
fix: downloading in non-tmp dir

### DIFF
--- a/crates/influxive-downloader/src/lib.rs
+++ b/crates/influxive-downloader/src/lib.rs
@@ -115,7 +115,10 @@ impl DownloadSpec {
             }
         }
 
-        // Fallback to copy() if rename() fails because of an `Invalid cross-device link` error
+        // `tokio::fs::rename()` can fail with an `Invalid cross-device link` error if the
+        // `fallback_path`is on different mount point then the temp folder where the file is
+        // downloaded (`dl_path`). Since `fallback_path` is not constrained to be on the same mount
+        // point, fallback to do copy and remove instead.
         if tokio::fs::rename(&dl_path, &fallback_path).await.is_err() {
             tokio::fs::copy(&dl_path, &fallback_path).await?;
             let _ = tokio::fs::remove_file(&dl_path).await;


### PR DESCRIPTION
Downloading influxDB binaries would fail if you provide a fallback path on a different mount point than `/tmp`.
This is because it is calling `tokio::fs::rename()` which gives error `Invalid cross-device link` since its renaming from `/tmp`.

The proposed fix is to fallback to `tokio::fs::copy()` if `rename()` fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file extraction process to handle failures more gracefully by adding a fallback mechanism if file renaming fails.

* **Tests**
  * Added a new asynchronous test to verify downloading and extraction behavior in the current directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->