### PR TITLE
test: integration test for influx file writer

### DIFF
--- a/crates/influxive-downloader/src/lib.rs
+++ b/crates/influxive-downloader/src/lib.rs
@@ -129,17 +129,18 @@ impl DownloadSpec {
         let file = tempfile::tempfile()?;
         let mut file = tokio::fs::File::from_std(file);
 
-        let response = reqwest::get(self.url)
-            .await
-            .map_err(err_other)?;
+        let response = reqwest::get(self.url).await.map_err(err_other)?;
         if !response.status().is_success() {
-            return Err(err_other(format!("Failed to download file: HTTP {}", response.status())));
+            return Err(err_other(format!(
+                "Failed to download file: HTTP {}",
+                response.status()
+            )));
         }
         let content_length = response.content_length();
         if let Some(size) = content_length {
             println!("Expected file size: {} bytes", size);
         }
-        
+
         let mut data_stream = response.bytes_stream();
         let mut hasher = self.archive_hash.get_hasher();
 
@@ -158,12 +159,10 @@ impl DownloadSpec {
             if bytes_count != expected_size {
                 return Err(err_other(format!(
                     "Downloaded size mismatch: expected {}, got {}",
-                    expected_size,
-                    bytes_count
+                    expected_size, bytes_count
                 )));
             }
         }
-
 
         let hash = hasher.finalize();
         if &*hash != self.archive_hash.as_slice() {

--- a/crates/influxive-writer/Cargo.toml
+++ b/crates/influxive-writer/Cargo.toml
@@ -17,8 +17,7 @@ tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true }
 
 [dev-dependencies]
-tempfile = "3.20.0"
+tempfile = { workspace = true }
 influxive-child-svc = { workspace = true }
 influxive-downloader = { workspace = true }
-reqwest = "0.12.22"
 hex-literal = { workspace = true }

--- a/crates/influxive-writer/Cargo.toml
+++ b/crates/influxive-writer/Cargo.toml
@@ -19,4 +19,6 @@ tracing = { workspace = true }
 [dev-dependencies]
 tempfile = "3.20.0"
 influxive-child-svc = { workspace = true }
+influxive-downloader = { workspace = true }
 reqwest = "0.12.22"
+hex-literal = { workspace = true }

--- a/crates/influxive-writer/Cargo.toml
+++ b/crates/influxive-writer/Cargo.toml
@@ -18,3 +18,5 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3.20.0"
+influxive-child-svc = { workspace = true }
+reqwest = "0.12.22"

--- a/crates/influxive-writer/tests/common/mod.rs
+++ b/crates/influxive-writer/tests/common/mod.rs
@@ -1,0 +1,2 @@
+pub mod telegraf_svc;
+pub mod telegraf_influx_file_conf;

--- a/crates/influxive-writer/tests/common/mod.rs
+++ b/crates/influxive-writer/tests/common/mod.rs
@@ -1,2 +1,2 @@
-pub mod telegraf_svc;
 pub mod telegraf_influx_file_conf;
+pub mod telegraf_svc;

--- a/crates/influxive-writer/tests/common/mod.rs
+++ b/crates/influxive-writer/tests/common/mod.rs
@@ -1,2 +1,3 @@
+pub mod telegraf_binaries;
 pub mod telegraf_influx_file_conf;
 pub mod telegraf_svc;

--- a/crates/influxive-writer/tests/common/telegraf_binaries.rs
+++ b/crates/influxive-writer/tests/common/telegraf_binaries.rs
@@ -23,8 +23,8 @@ pub const TELEGRAF_SPEC: DownloadSpec = DownloadSpec {
 ))]
 pub const TELEGRAF_SPEC: DownloadSpec = DownloadSpec {
     url: "https://dl.influxdata.com/telegraf/releases/telegraf-1.28.5_darwin_amd64.tar.gz",
-    archive: Archive::Zip {
-        inner_path: "telegraf-1.28.5/telegraf",
+    archive: Archive::TarGz {
+        inner_path: "telegraf-1.28.5/usr/bin/telegraf",
     },
     archive_hash: Hash::Sha2_256(&hex!(
             "0848074b210d4a40e4b22f6a8b3c48450428ad02f9f796c1e2d55dee8d441c5b"
@@ -33,7 +33,7 @@ pub const TELEGRAF_SPEC: DownloadSpec = DownloadSpec {
             "e6e2c820431aa9a89ee1a8ada2408c0a058e138bb5126ae27bcadb9624e5f2dc"
         )),
     file_prefix: "telegraf",
-    file_extension: ".exe",
+    file_extension: "",
 };
 
 #[cfg(all(target_os = "windows", target_arch = "x86_64"))]

--- a/crates/influxive-writer/tests/common/telegraf_binaries.rs
+++ b/crates/influxive-writer/tests/common/telegraf_binaries.rs
@@ -38,7 +38,7 @@ pub const TELEGRAF_SPEC: DownloadSpec = DownloadSpec {
 
 #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
 pub const TELEGRAF_SPEC: DownloadSpec = DownloadSpec {
-    url: "https://dl.influxdata.com/telegraf/releases/telegraf-1.28.5-windows-amd64.zip",
+    url: "https://dl.influxdata.com/telegraf/releases/telegraf-1.28.5_windows_amd64.zip",
     archive: Archive::Zip {
         inner_path: "telegraf-1.28.5/telegraf",
     },

--- a/crates/influxive-writer/tests/common/telegraf_binaries.rs
+++ b/crates/influxive-writer/tests/common/telegraf_binaries.rs
@@ -22,7 +22,7 @@ pub const TELEGRAF_SPEC: DownloadSpec = DownloadSpec {
     any(target_arch = "x86_64", target_arch = "aarch64")
 ))]
 pub const TELEGRAF_SPEC: DownloadSpec = DownloadSpec {
-    url: "https://dl.influxdata.com/telegraf/releases/telegraf-1.28.5_darwin_amd64.zip",
+    url: "https://dl.influxdata.com/telegraf/releases/telegraf-1.28.5_darwin_amd64.tar.gz",
     archive: Archive::Zip {
         inner_path: "telegraf-1.28.5/telegraf",
     },

--- a/crates/influxive-writer/tests/common/telegraf_binaries.rs
+++ b/crates/influxive-writer/tests/common/telegraf_binaries.rs
@@ -22,7 +22,7 @@ pub const TELEGRAF_SPEC: DownloadSpec = DownloadSpec {
     any(target_arch = "x86_64", target_arch = "aarch64")
 ))]
 pub const TELEGRAF_SPEC: DownloadSpec = DownloadSpec {
-    url: "https://dl.influxdata.com/telegraf/releases/telegraf-1.28.5-darwin-amd64.zip",
+    url: "https://dl.influxdata.com/telegraf/releases/telegraf-1.28.5_darwin_amd64.zip",
     archive: Archive::Zip {
         inner_path: "telegraf-1.28.5/telegraf",
     },

--- a/crates/influxive-writer/tests/common/telegraf_binaries.rs
+++ b/crates/influxive-writer/tests/common/telegraf_binaries.rs
@@ -43,10 +43,10 @@ pub const TELEGRAF_SPEC: DownloadSpec = DownloadSpec {
         inner_path: "telegraf-1.28.5/telegraf",
     },
     archive_hash: Hash::Sha2_256(&hex!(
-            "39eb8b73183b29b81cc6d2a23e1bb9afa1c5efa061be4074cccc2fa9c87d4b79"
+            "e025bdd57bad5174f2490da47983eff4aa9f0a884343c0629d6ef774dcf2a892"
         )),
     file_hash: Hash::Sha2_256(&hex!(
-            "d64176c8a102043e578dbba69181f75cfd975b5d5118d41ddfc621523ab8f7c9"
+            "df224de741f8ec4213c59be87d0206dbfd76dae337c9bd219516505577b07143"
         )),
     file_prefix: "telegraf",
     file_extension: ".exe",

--- a/crates/influxive-writer/tests/common/telegraf_binaries.rs
+++ b/crates/influxive-writer/tests/common/telegraf_binaries.rs
@@ -43,7 +43,7 @@ pub const TELEGRAF_SPEC: DownloadSpec = DownloadSpec {
         inner_path: "telegraf-1.28.5/telegraf",
     },
     archive_hash: Hash::Sha2_256(&hex!(
-            "924e103b33016a44247f97c7ee87bb807882d73d83181e31e251f6903b74fa1e"
+            "2c7b50d1f1befafdd31c79e788f744806a4e6ea9ddada85005d3f9f46a3082ae"
         )),
     file_hash: Hash::Sha2_256(&hex!(
             "d64176c8a102043e578dbba69181f75cfd975b5d5118d41ddfc621523ab8f7c9"

--- a/crates/influxive-writer/tests/common/telegraf_binaries.rs
+++ b/crates/influxive-writer/tests/common/telegraf_binaries.rs
@@ -43,7 +43,7 @@ pub const TELEGRAF_SPEC: DownloadSpec = DownloadSpec {
         inner_path: "telegraf-1.28.5/telegraf",
     },
     archive_hash: Hash::Sha2_256(&hex!(
-            "2c7b50d1f1befafdd31c79e788f744806a4e6ea9ddada85005d3f9f46a3082ae"
+            "39eb8b73183b29b81cc6d2a23e1bb9afa1c5efa061be4074cccc2fa9c87d4b79"
         )),
     file_hash: Hash::Sha2_256(&hex!(
             "d64176c8a102043e578dbba69181f75cfd975b5d5118d41ddfc621523ab8f7c9"

--- a/crates/influxive-writer/tests/common/telegraf_binaries.rs
+++ b/crates/influxive-writer/tests/common/telegraf_binaries.rs
@@ -40,7 +40,7 @@ pub const TELEGRAF_SPEC: DownloadSpec = DownloadSpec {
 pub const TELEGRAF_SPEC: DownloadSpec = DownloadSpec {
     url: "https://dl.influxdata.com/telegraf/releases/telegraf-1.28.5_windows_amd64.zip",
     archive: Archive::Zip {
-        inner_path: "telegraf-1.28.5/telegraf",
+        inner_path: "telegraf-1.28.5/telegraf.exe",
     },
     archive_hash: Hash::Sha2_256(&hex!(
             "e025bdd57bad5174f2490da47983eff4aa9f0a884343c0629d6ef774dcf2a892"

--- a/crates/influxive-writer/tests/common/telegraf_binaries.rs
+++ b/crates/influxive-writer/tests/common/telegraf_binaries.rs
@@ -1,0 +1,53 @@
+use hex_literal::hex;
+use influxive_downloader::{Archive, DownloadSpec, Hash};
+
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+pub const TELEGRAF_SPEC: DownloadSpec = DownloadSpec {
+    url: "https://dl.influxdata.com/telegraf/releases/telegraf-1.28.5_linux_amd64.tar.gz",
+    archive: Archive::TarGz {
+        inner_path: "telegraf-1.28.5/usr/bin/telegraf",
+    },
+    archive_hash: Hash::Sha2_256(&hex!(
+            "ae2f925e8e999299d4f4e6db7c20395813457edfb4128652d685cecb501ef669"
+        )),
+    file_hash: Hash::Sha2_256(&hex!(
+            "8e9e4cf36fd7ebda5270c53453153f4d551ea291574fdaed08e376eaf6d3700b"
+        )),
+    file_prefix: "telegraf",
+    file_extension: "",
+};
+
+#[cfg(all(
+    any(target_os = "macos", target_os = "ios", target_os = "tvos"),
+    any(target_arch = "x86_64", target_arch = "aarch64")
+))]
+pub const TELEGRAF_SPEC: DownloadSpec = DownloadSpec {
+    url: "https://dl.influxdata.com/telegraf/releases/telegraf-1.28.5-darwin-amd64.zip",
+    archive: Archive::Zip {
+        inner_path: "telegraf-1.28.5/telegraf",
+    },
+    archive_hash: Hash::Sha2_256(&hex!(
+            "0848074b210d4a40e4b22f6a8b3c48450428ad02f9f796c1e2d55dee8d441c5b"
+        )),
+    file_hash: Hash::Sha2_256(&hex!(
+            "e6e2c820431aa9a89ee1a8ada2408c0a058e138bb5126ae27bcadb9624e5f2dc"
+        )),
+    file_prefix: "telegraf",
+    file_extension: ".exe",
+};
+
+#[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+pub const TELEGRAF_SPEC: DownloadSpec = DownloadSpec {
+    url: "https://dl.influxdata.com/telegraf/releases/telegraf-1.28.5-windows-amd64.zip",
+    archive: Archive::Zip {
+        inner_path: "telegraf-1.28.5/telegraf",
+    },
+    archive_hash: Hash::Sha2_256(&hex!(
+            "924e103b33016a44247f97c7ee87bb807882d73d83181e31e251f6903b74fa1e"
+        )),
+    file_hash: Hash::Sha2_256(&hex!(
+            "d64176c8a102043e578dbba69181f75cfd975b5d5118d41ddfc621523ab8f7c9"
+        )),
+    file_prefix: "telegraf",
+    file_extension: ".exe",
+};

--- a/crates/influxive-writer/tests/common/telegraf_influx_file_conf.rs
+++ b/crates/influxive-writer/tests/common/telegraf_influx_file_conf.rs
@@ -1,14 +1,14 @@
 use std::fs::File;
 use std::io::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 pub struct TelegrafLineProtocolConfig {
     pub influxdb_url: String,
     pub token: String,
     pub organization: String,
     pub bucket: String,
-    pub metrics_file_path: String,
-    pub config_output_path: String,
+    pub metrics_file_path: PathBuf,
+    pub config_output_path: PathBuf,
 }
 
 impl TelegrafLineProtocolConfig {
@@ -25,7 +25,7 @@ impl TelegrafLineProtocolConfig {
 
         println!(
             "Telegraf Line Protocol configuration written to: {}",
-            self.config_output_path
+            self.config_output_path.as_path().display()
         );
         Ok(())
     }
@@ -84,7 +84,7 @@ impl TelegrafLineProtocolConfig {
             self.token,
             self.organization,
             self.bucket,
-            self.metrics_file_path,
+            self.metrics_file_path.as_path().display(),
         )
     }
 }
@@ -103,8 +103,8 @@ impl TelegrafLineProtocolConfigBuilder {
                 token: String::new(),
                 organization: String::new(),
                 bucket: String::new(),
-                metrics_file_path: "/tmp/app_metrics.log".to_string(),
-                config_output_path: "/tmp/telegraf.conf".to_string(),
+                metrics_file_path: PathBuf::from("app_metrics.log"),
+                config_output_path: PathBuf::from("telegraf.conf"),
             },
         }
     }
@@ -130,12 +130,12 @@ impl TelegrafLineProtocolConfigBuilder {
     }
 
     pub fn metrics_file_path(mut self, path: &str) -> Self {
-        self.config.metrics_file_path = path.to_string();
+        self.config.metrics_file_path = PathBuf::from(path);
         self
     }
 
     pub fn config_output_path(mut self, path: &str) -> Self {
-        self.config.config_output_path = path.to_string();
+        self.config.config_output_path = PathBuf::from(path);
         self
     }
 

--- a/crates/influxive-writer/tests/common/telegraf_influx_file_conf.rs
+++ b/crates/influxive-writer/tests/common/telegraf_influx_file_conf.rs
@@ -1,0 +1,145 @@
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+
+pub struct TelegrafLineProtocolConfig {
+    pub influxdb_url: String,
+    pub token: String,
+    pub organization: String,
+    pub bucket: String,
+    pub metrics_file_path: String,
+    pub config_output_path: String,
+}
+
+impl TelegrafLineProtocolConfig {
+    pub fn generate_file(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let config_content = self.build_content();
+
+        // Create parent directories if they don't exist
+        if let Some(parent) = Path::new(&self.config_output_path).parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        let mut file = File::create(&self.config_output_path)?;
+        file.write_all(config_content.as_bytes())?;
+
+        println!(
+            "Telegraf Line Protocol configuration written to: {}",
+            self.config_output_path
+        );
+        Ok(())
+    }
+
+    fn build_content(&self) -> String {
+        format!(
+            r#"# Generated Telegraf Configuration for Line Protocol Metrics
+
+[global_tags]
+  # Global tags can be specified here in key="value" format
+
+[agent]
+  interval = "5s"
+  round_interval = true
+  metric_batch_size = 1000
+  metric_buffer_limit = 10000
+  collection_jitter = "0s"
+  flush_interval = "5s"
+  flush_jitter = "0s"
+  precision = ""
+  hostname = ""
+  omit_hostname = false
+  quiet = false
+#  logfile = "logs_telegraf.log"
+
+# Configuration for InfluxDB v2 output
+[[outputs.influxdb_v2]]
+  ## The URLs of the InfluxDB cluster nodes.
+  urls = ["{}"]
+
+  ## Token for authentication
+  token = "{}"
+
+  ## Organization is the name of the organization you wish to write to
+  organization = "{}"
+
+  ## Destination bucket to write into
+  bucket = "{}"
+
+# Input plugin for reading Line Protocol metrics from file
+[[inputs.file]]
+  ## Files to parse each interval. Accept standard unix glob matching rules,
+  ## as well as ** to match recursive files and directories.
+  files = ["{}"]
+
+  ## Data format to consume.
+  data_format = "influx"
+
+  ## Character encoding to use when interpreting the file contents.  Invalid
+  ## characters are replaced using the unicode replacement character.  When set
+  ## to the empty string the encoding will be automatically determined.
+  character_encoding = "utf-8"
+"#,
+            self.influxdb_url,
+            self.token,
+            self.organization,
+            self.bucket,
+            self.metrics_file_path,
+        )
+    }
+}
+
+/// Builder pattern for easier configuration
+pub struct TelegrafLineProtocolConfigBuilder {
+    config: TelegrafLineProtocolConfig,
+}
+
+impl TelegrafLineProtocolConfigBuilder {
+    /// Constructor
+    pub fn new() -> Self {
+        Self {
+            config: TelegrafLineProtocolConfig {
+                influxdb_url: String::new(),
+                token: String::new(),
+                organization: String::new(),
+                bucket: String::new(),
+                metrics_file_path: "/tmp/app_metrics.log"
+                    .to_string(),
+                config_output_path: "/tmp/telegraf.conf".to_string(),
+            },
+        }
+    }
+
+    pub fn influxdb_url(mut self, url: &str) -> Self {
+        self.config.influxdb_url = url.to_string();
+        self
+    }
+
+    pub fn token(mut self, token: &str) -> Self {
+        self.config.token = token.to_string();
+        self
+    }
+
+    pub fn organization(mut self, org: &str) -> Self {
+        self.config.organization = org.to_string();
+        self
+    }
+
+    pub fn bucket(mut self, bucket: &str) -> Self {
+        self.config.bucket = bucket.to_string();
+        self
+    }
+
+    pub fn metrics_file_path(mut self, path: &str) -> Self {
+        self.config.metrics_file_path = path.to_string();
+        self
+    }
+
+    pub fn config_output_path(mut self, path: &str) -> Self {
+        self.config.config_output_path = path.to_string();
+        self
+    }
+
+    pub fn build(self) -> TelegrafLineProtocolConfig {
+        self.config
+    }
+}

--- a/crates/influxive-writer/tests/common/telegraf_influx_file_conf.rs
+++ b/crates/influxive-writer/tests/common/telegraf_influx_file_conf.rs
@@ -25,7 +25,10 @@ impl TelegrafLineProtocolConfig {
 
         println!(
             "Telegraf Line Protocol configuration written to: {}",
-            self.config_output_path.as_path().display()
+            self.config_output_path
+                .as_path()
+                .to_string_lossy()
+                .replace('\\', "\\\\"), // escape backslashes for Windows
         );
         Ok(())
     }

--- a/crates/influxive-writer/tests/common/telegraf_influx_file_conf.rs
+++ b/crates/influxive-writer/tests/common/telegraf_influx_file_conf.rs
@@ -1,6 +1,6 @@
 use std::fs::File;
 use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 pub struct TelegrafLineProtocolConfig {
     pub influxdb_url: String,
@@ -16,7 +16,7 @@ impl TelegrafLineProtocolConfig {
         let config_content = self.build_content();
 
         // Create parent directories if they don't exist
-        if let Some(parent) = Path::new(&self.config_output_path).parent() {
+        if let Some(parent) = self.config_output_path.parent() {
             std::fs::create_dir_all(parent)?;
         }
 
@@ -106,7 +106,7 @@ impl TelegrafLineProtocolConfigBuilder {
                 token: String::new(),
                 organization: String::new(),
                 bucket: String::new(),
-                metrics_file_path: PathBuf::from("app_metrics.log"),
+                metrics_file_path: PathBuf::from("metrics.influx"),
                 config_output_path: PathBuf::from("telegraf.conf"),
             },
         }

--- a/crates/influxive-writer/tests/common/telegraf_influx_file_conf.rs
+++ b/crates/influxive-writer/tests/common/telegraf_influx_file_conf.rs
@@ -73,22 +73,22 @@ impl TelegrafLineProtocolConfig {
 # Configuration for InfluxDB v2 output
 [[outputs.influxdb_v2]]
   ## The URLs of the InfluxDB cluster nodes.
-  urls = ["{}"]
+  urls = ["{url}"]
 
   ## Token for authentication
-  token = "{}"
+  token = "{token}"
 
   ## Organization is the name of the organization you wish to write to
-  organization = "{}"
+  organization = "{org}"
 
   ## Destination bucket to write into
-  bucket = "{}"
+  bucket = "{bucket}"
 
 # Input plugin for reading Line Protocol metrics from file
 [[inputs.file]]
   ## Files to parse each interval. Accept standard unix glob matching rules,
   ## as well as ** to match recursive files and directories.
-  files = ["{}"]
+  files = ["{filepath}"]
 
   ## Data format to consume.
   data_format = "influx"
@@ -98,11 +98,12 @@ impl TelegrafLineProtocolConfig {
   ## to the empty string the encoding will be automatically determined.
   character_encoding = "utf-8"
 "#,
-            self.influxdb_url,
-            self.token,
-            self.organization,
-            self.bucket,
-            self.metrics_file_path
+            url = self.influxdb_url,
+            token = self.token,
+            org = self.organization,
+            bucket = self.bucket,
+            filepath = self
+                .metrics_file_path
                 .as_path()
                 .to_string_lossy()
                 .replace('\\', "\\\\"), // escape backslashes for Windows

--- a/crates/influxive-writer/tests/common/telegraf_influx_file_conf.rs
+++ b/crates/influxive-writer/tests/common/telegraf_influx_file_conf.rs
@@ -25,10 +25,7 @@ impl TelegrafLineProtocolConfig {
 
         println!(
             "Telegraf Line Protocol configuration written to: {}",
-            self.config_output_path
-                .as_path()
-                .to_string_lossy()
-                .replace('\\', "\\\\"), // escape backslashes for Windows
+            self.config_output_path.as_path().to_string_lossy(),
         );
         Ok(())
     }
@@ -87,7 +84,10 @@ impl TelegrafLineProtocolConfig {
             self.token,
             self.organization,
             self.bucket,
-            self.metrics_file_path.as_path().display(),
+            self.metrics_file_path
+                .as_path()
+                .to_string_lossy()
+                .replace('\\', "\\\\"), // escape backslashes for Windows
         )
     }
 }

--- a/crates/influxive-writer/tests/common/telegraf_influx_file_conf.rs
+++ b/crates/influxive-writer/tests/common/telegraf_influx_file_conf.rs
@@ -30,6 +30,7 @@ impl TelegrafLineProtocolConfig {
         Ok(())
     }
 
+    /// Builds Telegraf config file content based on config
     fn build_content(&self) -> String {
         format!(
             r#"# Generated Telegraf Configuration for Line Protocol Metrics
@@ -102,8 +103,7 @@ impl TelegrafLineProtocolConfigBuilder {
                 token: String::new(),
                 organization: String::new(),
                 bucket: String::new(),
-                metrics_file_path: "/tmp/app_metrics.log"
-                    .to_string(),
+                metrics_file_path: "/tmp/app_metrics.log".to_string(),
                 config_output_path: "/tmp/telegraf.conf".to_string(),
             },
         }

--- a/crates/influxive-writer/tests/common/telegraf_svc.rs
+++ b/crates/influxive-writer/tests/common/telegraf_svc.rs
@@ -1,68 +1,29 @@
-use hex_literal::hex;
-use influxive_downloader::{Archive, DownloadSpec, Hash};
+use crate::common::telegraf_binaries::TELEGRAF_SPEC;
 use std::path::Path;
 use std::process::Stdio;
-
-const TELEGRAF_TAR: DownloadSpec = DownloadSpec {
-    url: "https://dl.influxdata.com/telegraf/releases/telegraf-1.28.5_linux_amd64.tar.gz",
-    archive: Archive::TarGz {
-        inner_path: "telegraf-1.28.5/usr/bin/telegraf",
-    },
-    archive_hash: Hash::Sha2_256(&hex!(
-            "ae2f925e8e999299d4f4e6db7c20395813457edfb4128652d685cecb501ef669"
-        )),
-    file_hash: Hash::Sha2_256(&hex!(
-            "8e9e4cf36fd7ebda5270c53453153f4d551ea291574fdaed08e376eaf6d3700b"
-        )),
-    file_prefix: "telegraf",
-    file_extension: "",
-};
-
-const TELEGRAF_ZIP: DownloadSpec = DownloadSpec {
-    url: "https://dl.influxdata.com/telegraf/releases/telegraf-1.28.5-windows-amd64.zip",
-    archive: Archive::Zip {
-        inner_path: "telegraf-1.28.5/telegraf",
-    },
-    archive_hash: Hash::Sha2_256(&hex!(
-            "924e103b33016a44247f97c7ee87bb807882d73d83181e31e251f6903b74fa1e"
-        )),
-    file_hash: Hash::Sha2_256(&hex!(
-            "d64176c8a102043e578dbba69181f75cfd975b5d5118d41ddfc621523ab8f7c9"
-        )),
-    file_prefix: "telegraf",
-    file_extension: ".exe",
-};
 
 /// Spawns and handles a Telegraf child service
 pub struct TelegrafSvc {
     process: Option<tokio::process::Child>,
     config_path: String,
     binary_dir: String,
-    spec: DownloadSpec,
 }
 
 impl TelegrafSvc {
     pub fn new(config_path: &str, fallback_binary_dir: &str) -> Self {
-        // Detect OS
-        let spec = match std::env::consts::OS {
-            "linux" | "macos" => TELEGRAF_TAR,
-            "windows" => TELEGRAF_ZIP,
-            _ => panic!("Unsupported OS: {}", std::env::consts::OS),
-        };
-
         Self {
             process: None,
             config_path: config_path.to_string(),
             binary_dir: fallback_binary_dir.to_string(),
-            spec,
         }
     }
 
     async fn download_telegraf(
         &self,
     ) -> Result<std::path::PathBuf, Box<dyn std::error::Error>> {
-        println!("Downloading from: {}", self.spec.url);
-        let filepath = self.spec.download(Path::new(&self.binary_dir)).await?;
+        println!("Downloading from: {}", TELEGRAF_SPEC.url);
+        let filepath =
+            TELEGRAF_SPEC.download(Path::new(&self.binary_dir)).await?;
         println!(
             "Telegraf binary downloaded and extracted successfully to {}",
             filepath.display()
@@ -84,6 +45,7 @@ impl TelegrafSvc {
             .arg(&self.config_path)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
+            .kill_on_drop(true)
             .spawn()?;
 
         self.process = Some(child);
@@ -100,16 +62,5 @@ impl TelegrafSvc {
             println!("Telegraf stopped");
         }
         Ok(())
-    }
-}
-
-impl Drop for TelegrafSvc {
-    fn drop(&mut self) {
-        if let Some(child) = self.process.take() {
-            // Use blocking kill since we can't await in Drop
-            let _ = std::process::Command::new("kill")
-                .arg(child.id().unwrap_or(0).to_string())
-                .output();
-        }
     }
 }

--- a/crates/influxive-writer/tests/common/telegraf_svc.rs
+++ b/crates/influxive-writer/tests/common/telegraf_svc.rs
@@ -123,7 +123,7 @@ impl TelegrafSvc {
                     archive_path
                 );
 
-                // Copy to our bin directory
+                // Locate binary in the extracted archive and copy to the provided bin directory
                 let filename = format!("telegraf-{}", TELEGRAF_VERSION);
                 let extracted_dir =
                     PathBuf::from(&self.binary_dir).join(filename);

--- a/crates/influxive-writer/tests/common/telegraf_svc.rs
+++ b/crates/influxive-writer/tests/common/telegraf_svc.rs
@@ -56,7 +56,7 @@ impl Drop for TelegrafSvc {
             println!("Error killing Telegraf: {}", err);
         } else {
             if let Err(err) = self.process.wait() {
-                println!("Error killing Telegraf: {}", err);
+                println!("Error waiting for Telegraf to exit: {}", err);
             } else {
                 println!("Telegraf stopped");
             }

--- a/crates/influxive-writer/tests/common/telegraf_svc.rs
+++ b/crates/influxive-writer/tests/common/telegraf_svc.rs
@@ -4,64 +4,52 @@ use std::process::Stdio;
 
 /// Spawns and handles a Telegraf child service
 pub struct TelegrafSvc {
-    process: Option<tokio::process::Child>,
-    config_path: PathBuf,
-    binary_dir: PathBuf,
+    _process: tokio::process::Child,
 }
 
 impl TelegrafSvc {
-    pub fn new(config_path: &str, fallback_binary_dir: &str) -> Self {
-        Self {
-            process: None,
-            config_path: PathBuf::from(config_path),
-            binary_dir: PathBuf::from(fallback_binary_dir),
-        }
+    pub async fn spawn(
+        config_path: &str,
+        fallback_binary_dir: &str,
+    ) -> std::io::Result<Self> {
+        // Ensure binary is available
+        let filepath =
+            TelegrafSvc::download_telegraf(fallback_binary_dir).await?;
+
+        println!(
+            "Starting Telegraf with config: {} | {}",
+            config_path,
+            filepath.to_string_lossy(),
+        );
+
+        let child = tokio::process::Command::new(&filepath)
+            .arg("--config")
+            .arg(&config_path)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()?;
+
+        println!("Telegraf started successfully");
+
+        Ok(Self { _process: child })
     }
 
-    async fn download_telegraf(
-        &self,
-    ) -> Result<std::path::PathBuf, Box<dyn std::error::Error>> {
+    async fn download_telegraf(binary_dir: &str) -> std::io::Result<PathBuf> {
         println!("Downloading from: {}", TELEGRAF_SPEC.url);
-        let filepath =
-            TELEGRAF_SPEC.download(self.binary_dir.as_path()).await?;
+        let filepath = TELEGRAF_SPEC
+            .download(PathBuf::from(binary_dir).as_path())
+            .await?;
         println!(
             "Telegraf binary downloaded and extracted successfully to {}",
             filepath.display()
         );
         Ok(filepath)
     }
+}
 
-    pub async fn start(&mut self) -> Result<(), Box<dyn std::error::Error>> {
-        // Ensure binary is available
-        let filepath = self.download_telegraf().await?;
-
-        println!(
-            "Starting Telegraf with config: {} | {}",
-            self.config_path.to_string_lossy(),
-            filepath.to_string_lossy(),
-        );
-
-        let child = tokio::process::Command::new(&filepath)
-            .arg("--config")
-            .arg(&self.config_path)
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .kill_on_drop(true)
-            .spawn()?;
-
-        self.process = Some(child);
-
-        println!("Telegraf started successfully");
-        Ok(())
-    }
-
-    pub async fn stop(&mut self) -> Result<(), Box<dyn std::error::Error>> {
-        if let Some(mut child) = self.process.take() {
-            println!("Stopping Telegraf...");
-            child.kill().await?;
-            child.wait().await?;
-            println!("Telegraf stopped");
-        }
-        Ok(())
+impl Drop for TelegrafSvc {
+    fn drop(&mut self) {
+        println!("Telegraf stopped");
     }
 }

--- a/crates/influxive-writer/tests/common/telegraf_svc.rs
+++ b/crates/influxive-writer/tests/common/telegraf_svc.rs
@@ -1,20 +1,20 @@
 use crate::common::telegraf_binaries::TELEGRAF_SPEC;
-use std::path::Path;
+use std::path::PathBuf;
 use std::process::Stdio;
 
 /// Spawns and handles a Telegraf child service
 pub struct TelegrafSvc {
     process: Option<tokio::process::Child>,
-    config_path: String,
-    binary_dir: String,
+    config_path: PathBuf,
+    binary_dir: PathBuf,
 }
 
 impl TelegrafSvc {
     pub fn new(config_path: &str, fallback_binary_dir: &str) -> Self {
         Self {
             process: None,
-            config_path: config_path.to_string(),
-            binary_dir: fallback_binary_dir.to_string(),
+            config_path: PathBuf::from(config_path),
+            binary_dir: PathBuf::from(fallback_binary_dir),
         }
     }
 
@@ -23,7 +23,7 @@ impl TelegrafSvc {
     ) -> Result<std::path::PathBuf, Box<dyn std::error::Error>> {
         println!("Downloading from: {}", TELEGRAF_SPEC.url);
         let filepath =
-            TELEGRAF_SPEC.download(Path::new(&self.binary_dir)).await?;
+            TELEGRAF_SPEC.download(self.binary_dir.as_path()).await?;
         println!(
             "Telegraf binary downloaded and extracted successfully to {}",
             filepath.display()
@@ -36,8 +36,9 @@ impl TelegrafSvc {
         let filepath = self.download_telegraf().await?;
 
         println!(
-            "Starting Telegraf with config: {} | {:?}",
-            self.config_path, filepath
+            "Starting Telegraf with config: {} | {}",
+            self.config_path.to_string_lossy(),
+            filepath.to_string_lossy(),
         );
 
         let child = tokio::process::Command::new(&filepath)

--- a/crates/influxive-writer/tests/common/telegraf_svc.rs
+++ b/crates/influxive-writer/tests/common/telegraf_svc.rs
@@ -1,8 +1,7 @@
+use hex_literal::hex;
+use influxive_downloader::{Archive, DownloadSpec, Hash};
 use std::path::Path;
 use std::process::Stdio;
-use influxive_downloader::{Archive, DownloadSpec, Hash};
-use hex_literal::hex;
-
 
 const TELEGRAF_TAR: DownloadSpec = DownloadSpec {
     url: "https://dl.influxdata.com/telegraf/releases/telegraf-1.28.5_linux_amd64.tar.gz",
@@ -34,7 +33,6 @@ const TELEGRAF_ZIP: DownloadSpec = DownloadSpec {
     file_extension: ".exe",
 };
 
-
 /// Spawns and handles a Telegraf child service
 pub struct TelegrafSvc {
     process: Option<tokio::process::Child>,
@@ -65,7 +63,10 @@ impl TelegrafSvc {
     ) -> Result<std::path::PathBuf, Box<dyn std::error::Error>> {
         println!("Downloading from: {}", self.spec.url);
         let filepath = self.spec.download(Path::new(&self.binary_dir)).await?;
-        println!("Telegraf binary downloaded and extracted successfully to {}", filepath.display());
+        println!(
+            "Telegraf binary downloaded and extracted successfully to {}",
+            filepath.display()
+        );
         Ok(filepath)
     }
 
@@ -75,8 +76,7 @@ impl TelegrafSvc {
 
         println!(
             "Starting Telegraf with config: {} | {:?}",
-            self.config_path,
-            filepath
+            self.config_path, filepath
         );
 
         let child = tokio::process::Command::new(&filepath)

--- a/crates/influxive-writer/tests/common/telegraf_svc.rs
+++ b/crates/influxive-writer/tests/common/telegraf_svc.rs
@@ -1,0 +1,211 @@
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+
+static TELEGRAF_VERSION: &str = "1.28.5";
+
+/// Spawns and handles a Telegraf child service
+pub struct TelegrafSvc {
+    process: Option<tokio::process::Child>,
+    config_path: String,
+    binary_dir: String,
+}
+
+impl TelegrafSvc {
+    fn binary_path(&self) -> PathBuf {
+        PathBuf::from(&self.binary_dir).join("telegraf")
+    }
+
+    pub fn new(config_path: &str, binary_path: &str) -> Self {
+        Self {
+            process: None,
+            config_path: config_path.to_string(),
+            binary_dir: binary_path.to_string(),
+        }
+    }
+
+    pub async fn ensure_binary(
+        &self,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        if self.binary_path().exists() {
+            println!("Telegraf binary already exists at {}", self.binary_dir);
+            return Ok(());
+        }
+
+        println!("Downloading Telegraf binary...");
+        self.download_telegraf().await?;
+        Ok(())
+    }
+
+    async fn download_telegraf(
+        &self,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        std::fs::create_dir_all(&self.binary_dir)?;
+
+        // Detect OS and architecture
+        let os = std::env::consts::OS;
+        let arch = std::env::consts::ARCH;
+
+        let (platform, extension) = match os {
+            "linux" => ("linux", "tar.gz"),
+            "macos" => ("darwin", "tar.gz"),
+            "windows" => ("windows", "zip"),
+            _ => return Err(format!("Unsupported OS: {}", os).into()),
+        };
+
+        let arch_name = match arch {
+            "x86_64" => "amd64",
+            "aarch64" => "arm64",
+            _ => {
+                return Err(format!("Unsupported architecture: {}", arch).into())
+            }
+        };
+
+        let filename = format!(
+            "telegraf-{}_{}_{}.{}",
+            TELEGRAF_VERSION, platform, arch_name, extension
+        );
+        let url =
+            format!("https://dl.influxdata.com/telegraf/releases/{}", filename);
+
+        println!("Downloading from: {}", url);
+
+        // Download the archive
+        let client = reqwest::Client::new();
+        let response = client.get(&url).send().await?;
+
+        if !response.status().is_success() {
+            return Err(format!(
+                "Failed to download Telegraf: HTTP {}",
+                response.status()
+            )
+            .into());
+        }
+
+        let archive_bytes = response.bytes().await?;
+        let temp_file = format!("{}/{}", self.binary_dir, filename);
+        std::fs::write(&temp_file, &archive_bytes)?;
+        println!("Telegraf binary downloaded successfully to {}", temp_file);
+
+        // Extract the archive
+        self.extract_telegraf(&temp_file, extension).await?;
+
+        // Clean up temp file
+        std::fs::remove_file(&temp_file)?;
+
+        println!("Telegraf binary downloaded and extracted successfully");
+        Ok(())
+    }
+
+    async fn extract_telegraf(
+        &self,
+        archive_path: &str,
+        extension: &str,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        match extension {
+            "tar.gz" => {
+                // Use tokio process to run tar command
+                let output = tokio::process::Command::new("tar")
+                    .args(&["-xzf", archive_path])
+                    .args(&["-C", self.binary_dir.as_str()])
+                    .output()
+                    .await?;
+
+                if !output.status.success() {
+                    return Err(format!(
+                        "Failed to extract {}: {} ",
+                        archive_path,
+                        String::from_utf8_lossy(&output.stderr)
+                    )
+                    .into());
+                }
+                println!(
+                    "Telegraf binary extracted successfully: {}",
+                    archive_path
+                );
+
+                // Copy to our bin directory
+                let filename = format!("telegraf-{}", TELEGRAF_VERSION);
+                let extracted_dir =
+                    PathBuf::from(&self.binary_dir).join(filename);
+                let extracted_bin_path = Path::new(&extracted_dir)
+                    .join("usr")
+                    .join("bin")
+                    .join("telegraf");
+                tokio::fs::copy(&extracted_bin_path, &self.binary_path())
+                    .await?;
+
+                // Make it executable
+                tokio::process::Command::new("chmod")
+                    .args(&[
+                        "+x",
+                        self.binary_path()
+                            .as_path()
+                            .as_os_str()
+                            .to_str()
+                            .unwrap(),
+                    ])
+                    .output()
+                    .await?;
+
+                println!("Telegraf binary made executable {}", self.binary_dir);
+            }
+            "zip" => {
+                // For Windows, we'd need to handle zip extraction
+                return Err("ZIP extraction not implemented for now".into());
+            }
+            _ => {
+                return Err(format!(
+                    "Unsupported archive format: {}",
+                    extension
+                )
+                .into())
+            }
+        }
+
+        Ok(())
+    }
+
+    pub async fn start(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        // Ensure binary is available
+        self.ensure_binary().await?;
+
+        println!(
+            "Starting Telegraf with config: {} | {}",
+            self.config_path,
+            self.binary_path().as_os_str().to_str().unwrap()
+        );
+
+        let child = tokio::process::Command::new(&self.binary_path())
+            .arg("--config")
+            .arg(&self.config_path)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()?;
+
+        self.process = Some(child);
+
+        println!("Telegraf started successfully");
+        Ok(())
+    }
+
+    pub async fn stop(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        if let Some(mut child) = self.process.take() {
+            println!("Stopping Telegraf...");
+            child.kill().await?;
+            child.wait().await?;
+            println!("Telegraf stopped");
+        }
+        Ok(())
+    }
+}
+
+impl Drop for TelegrafSvc {
+    fn drop(&mut self) {
+        if let Some(child) = self.process.take() {
+            // Use blocking kill since we can't await in Drop
+            let _ = std::process::Command::new("kill")
+                .arg(child.id().unwrap_or(0).to_string())
+                .output();
+        }
+    }
+}

--- a/crates/influxive-writer/tests/file.rs
+++ b/crates/influxive-writer/tests/file.rs
@@ -110,7 +110,7 @@ async fn write_to_file_then_read() {
     // result or a timeout
     let start = std::time::Instant::now();
     let mut line_count = 0;
-    while start.elapsed() < std::time::Duration::from_secs(60) {
+    while start.elapsed() < std::time::Duration::from_secs(20) {
         let result = influx_process
             .query(
                 r#"from(bucket: "influxive")

--- a/crates/influxive-writer/tests/file.rs
+++ b/crates/influxive-writer/tests/file.rs
@@ -1,0 +1,132 @@
+use influxive_child_svc::{InfluxiveChildSvc, InfluxiveChildSvcConfig};
+use influxive_core::*;
+use influxive_writer::*;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+use crate::common::telegraf_influx_file_conf::TelegrafLineProtocolConfigBuilder;
+use crate::common::telegraf_svc::TelegrafSvc;
+
+mod common;
+
+/// Setup InfluxiveWriter to use LineProtocolFileBackendFactory
+pub fn create_influx_file_writer(test_path: &PathBuf) -> InfluxiveWriter {
+    let _ = std::fs::remove_file(&test_path);
+    let mut config =
+        InfluxiveWriterConfig::create_with_influx_file(test_path.clone());
+    config.batch_duration = std::time::Duration::from_millis(30);
+    let writer = InfluxiveWriter::with_token_auth(config.clone(), "", "", "");
+    writer
+}
+
+/// Spawn influxDB with the default config
+async fn spawn_influx(path: &Path) -> InfluxiveChildSvc {
+    let child = InfluxiveChildSvc::new(
+        InfluxiveChildSvcConfig::default()
+            .with_database_path(Some(path.into()))
+            .with_metric_write(
+                InfluxiveWriterConfig::default()
+                    .with_batch_duration(std::time::Duration::from_millis(5)),
+            ),
+    )
+    .await
+    .unwrap();
+
+    child.ping().await.unwrap();
+
+    child
+}
+
+async fn write_to_file(test_path: &PathBuf) {
+    use std::io::BufRead;
+
+    let writer = create_influx_file_writer(test_path);
+
+    // Write one metric
+    writer.write_metric(
+        Metric::new(std::time::SystemTime::now(), "my-metric")
+            .with_field("f1", 1.77)
+            .with_field("f2", 2.77)
+            .with_field("f3", 3.77)
+            .with_tag("tag", "test-tag")
+            .with_tag("tag2", "test-tag2"),
+    );
+
+    // Write many metrics
+    let now = std::time::SystemTime::now().checked_sub(Duration::from_secs(10)).unwrap();
+    for n in 0..10 {
+        writer.write_metric(
+            Metric::new(now.checked_add(Duration::from_secs(n)).unwrap(), "my-second-metric")
+                .with_field("val", n),
+        );
+    }
+
+    // Wait for batch processing to trigger
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let file = std::fs::File::open(&test_path).unwrap();
+    let reader = std::io::BufReader::new(file);
+    let count = reader.lines().count();
+    assert_eq!(count, 11);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn write_to_file_then_read() {
+    let test_dir = tempfile::tempdir().unwrap().path().to_owned();
+    //let test_dir = std::env::current_dir().unwrap().join("output");
+    std::fs::create_dir_all(&test_dir).unwrap();
+    let metrics_path = test_dir.join("test_metrics.influx");
+    let telegraf_config_path = test_dir.join("test_telegraf.conf");
+
+    // Write metrics to disk
+    write_to_file(&metrics_path).await;
+
+    // Launch influxDB
+    let influx_process = spawn_influx(&test_dir).await;
+
+    // Generate Telegraf config
+
+    let config = TelegrafLineProtocolConfigBuilder::new()
+        .influxdb_url(influx_process.get_host())
+        .token(influx_process.get_token())
+        .organization("influxive")
+        .bucket("influxive")
+        .metrics_file_path(metrics_path.to_str().unwrap())
+        .config_output_path(telegraf_config_path.to_str().unwrap())
+        .build();
+    assert!(config.generate_file().is_ok());
+
+    // Launch Telegraf
+    let mut telegraf_process = TelegrafSvc::new(
+        telegraf_config_path.to_str().unwrap(),
+        test_dir.to_str().unwrap(),
+    );
+    telegraf_process.start().await.unwrap();
+
+
+    // Wait for telegraf to process by querying every second until a timeout
+    let start = std::time::Instant::now();
+    let mut line_count = 0;
+    while start.elapsed() < std::time::Duration::from_secs(20) {
+        // Query InfluxDB for data
+        let result = influx_process
+            .query(
+                r#"from(bucket: "influxive")
+|> range(start: -15m, stop: now())
+|> filter(fn: (r) => r["_measurement"] == "my-second-metric")
+|> filter(fn: (r) => r["_field"] == "val")"#,
+            )
+            .await
+            .unwrap();
+
+        line_count = result.split('\n').filter(|l| l.contains("my-second-metric")).count();
+        if line_count == 10 {
+            break;
+        }
+
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+    }
+
+    assert_eq!(line_count, 10);
+
+    telegraf_process.stop().await.unwrap();
+}

--- a/crates/influxive-writer/tests/file.rs
+++ b/crates/influxive-writer/tests/file.rs
@@ -106,11 +106,12 @@ async fn write_to_file_then_read() {
     assert!(config.write_to_file(telegraf_config_path.as_path()).is_ok());
 
     // Launch Telegraf
-    let mut telegraf_process = TelegrafSvc::new(
+    let _telegraf_process = TelegrafSvc::spawn(
         telegraf_config_path.to_str().unwrap(),
         test_dir.to_str().unwrap(),
-    );
-    telegraf_process.start().await.unwrap();
+    )
+    .await
+    .unwrap();
 
     // Wait for telegraf to process by querying influxDB every second until we get the expected
     // result or a timeout
@@ -139,6 +140,4 @@ async fn write_to_file_then_read() {
     }
 
     assert_eq!(line_count, 10);
-
-    telegraf_process.stop().await.unwrap();
 }

--- a/crates/influxive-writer/tests/file.rs
+++ b/crates/influxive-writer/tests/file.rs
@@ -139,11 +139,10 @@ async fn write_to_file_then_read() {
             tokio::time::sleep(std::time::Duration::from_secs(1)).await;
         }
     })
-    .await;
-
-    if let Err(_e) = res {
+    .await
+    .unwrap_or_else(|_| {
         panic!(
             "Error: Test timed out. line_count = {line_count} ; Expected: 10"
-        );
-    }
+        )
+    });
 }


### PR DESCRIPTION
Implemented an integration test for the influx file InfluxWriter:
1. writes some metrics to disk with InfluxWriter
2. launch an influxDB child service
3. generate Telegraf config
4. launch a Telegraf child service
5. query influxDB and check data has been successfully loaded into influxDB


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added utilities for generating Telegraf configuration files and managing Telegraf processes for testing.
  * Introduced an end-to-end test for writing metrics to a file, ingesting them via Telegraf, and verifying them in InfluxDB.
  * Added platform-specific automated downloading and verification of Telegraf binaries.

* **Tests**
  * Expanded the test suite with helpers and integration tests covering file-based metric writing and ingestion workflows.

* **Chores**
  * Updated development dependencies to support new test and integration features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->