### PR TITLE
feat: API for writing metrics to InfluxDB file

### DIFF
--- a/crates/influxive/README.md
+++ b/crates/influxive/README.md
@@ -59,4 +59,28 @@ let m = opentelemetry_api::global::meter("my.meter")
 m.record(3.14, &[]);
 ```
 
+### Writing to an influx file
+
+```rust
+// create our meter provider
+let meter_provider = influxive::influxive_file_meter_provider(
+    influxive::InfluxiveWriterConfig::create_with_influx_file(std::path::PathBuf::from("my-metrics.influx")),
+    influxive::InfluxiveMeterProviderConfig::default(),
+);
+
+// register our meter provider
+opentelemetry_api::global::set_meter_provider(meter_provider);
+
+// create a metric
+let m = opentelemetry_api::global::meter("my.meter")
+    .f64_histogram("my.metric")
+    .init();
+
+// make a recording
+m.record(3.14, &[]);
+
+// Read and use data in "my-metrics.influx"
+
+```
+
 <!-- cargo-rdme end -->

--- a/crates/influxive/src/test.rs
+++ b/crates/influxive/src/test.rs
@@ -1,0 +1,40 @@
+use super::*;
+use std::io::BufRead;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn file_meter_provider_one_metric_one_value() {
+    let tmp = tempfile::tempdir().unwrap();
+    let test_path = tmp
+        .path()
+        .join(std::path::PathBuf::from("unit_test_metrics.influx"));
+
+    // create our meter provider
+    let meter_provider = influxive_file_meter_provider(
+        InfluxiveWriterConfig::create_with_influx_file(test_path.clone()),
+        InfluxiveMeterProviderConfig::default(),
+    );
+
+    // register our meter provider
+    opentelemetry_api::global::set_meter_provider(meter_provider);
+
+    // create a metric
+    let m = opentelemetry_api::global::meter("my.meter")
+        .f64_histogram("my.metric")
+        .init();
+
+    // make a recording
+    m.record(3.14, &[]);
+
+    // Wait for the metric to be written
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    // Check file content for metric
+    let file = std::fs::File::open(&test_path).unwrap();
+    let reader = std::io::BufReader::new(file);
+    let res = reader.lines().next().transpose().unwrap();
+    assert!(res.is_some());
+    let line = res.unwrap();
+    let split = line.split(' ').collect::<Vec<&str>>();
+    assert_eq!(split[0], "my.metric");
+    assert!(split[1].contains(&"3.14"));
+}


### PR DESCRIPTION
Adds high level function `influxive_file_meter_provider()` with test and example.

Final PR for https://github.com/holochain/influxive/issues/17

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for writing metrics directly to a local InfluxDB line protocol file.
  * Introduced a new example in the documentation demonstrating file-based metric recording.

* **Documentation**
  * Expanded the README with an example on writing metrics to a file.

* **Tests**
  * Added a test to verify that metrics are correctly written to a file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->